### PR TITLE
switch to https

### DIFF
--- a/gateworks/gsc-update/Makefile
+++ b/gateworks/gsc-update/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.6
 PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=git://github.com/Gateworks/gsc_update
+PKG_SOURCE_URL:=https://github.com/Gateworks/gsc_update
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=87acabd1101c673c5f8c97eec4d35358bc3df3d7
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz


### PR DESCRIPTION
github recently made some changes which disallows
cloning anonymously this using the git url. (as is done in OpenWRT upon building)

Switch to https as instructed by github to fix this.

Signed-off-by: Koen Vandeputte <koen.vandeputte@ncentric.com>